### PR TITLE
Add history support and osmpbf-outline tool

### DIFF
--- a/README
+++ b/README
@@ -4,13 +4,29 @@ OSM PBF
 
 See http://wiki.openstreetmap.org/wiki/PBF_Format .
 
+There is a Java and a C version of the PBF library code here.
+
+C Version
+=========
+
+To compile:
+  cd src
+  make
+
+To install:
+  cd src
+  make install
+
+To build the Debian/Ubuntu package call:
+  debuild -I -us -uc
+
+To install the Debian/Ubuntu package call:
+  sudo dpkg --install ../libosmpbf-dev*.deb
+
 To include in your program use:
 
 #include <osmpbf/osmpbf.h>
 
 and link with:
     -lpthread -lz -lprotobuf-lite -losmpbf
-
-To build the Debian/Ubuntu package call:
-    debuild -I -us -uc
 


### PR DESCRIPTION
Peter Körner and I have been working on this. These are the changes:
- Now supports visible flag and HistoricalInformation feature as discussed on the osm-dev list.
- Peter wrote osmpbf-outline to help with debugging, manpage is included. Everything in the tools directory.
- There is a new osmpbf.h which is now the preferred way of using the lib, it includes the other two .h files and defines some commonly used consts.
- I added a magic file.
- The debian package includes all this.
- The debian package is numbered 1.1.1j2, which is your last used version number (1.1.1) with sub-version j(ochen)2. If you pull this and give it a new version number, you should put your new version number in osmpbf.h and debian/changelog.
