### PR TITLE
Add fields for replication support.

### DIFF
--- a/src/osmformat.proto
+++ b/src/osmformat.proto
@@ -62,6 +62,19 @@ message HeaderBlock {
 
   optional string writingprogram = 16; 
   optional string source = 17; // From the bbox field.
+
+  /* Tags that allow continuing an Osmosis replication */
+
+  // replication timestamp, expressed in seconds since the epoch, 
+  // otherwise the same value as in the "timestamp=..." field
+  // in the state.txt file used by Osmosis
+  optional int64 osmosis_replication_timestamp = 32;
+
+  // replication sequence number (sequenceNumber in state.txt)
+  optional int64 osmosis_replication_sequence_number = 33;
+
+  // replication base URL (from Osmosis' configuration.txt file)
+  optional string osmosis_replication_base_url = 34;
 }
 
 


### PR DESCRIPTION
This adds three fields to the header block in order to allow Osmosis replication data to be added to the header. If proper support is built into the handling program then files like this could be appended to without the need for external metadata. See http://lists.openstreetmap.org/pipermail/dev/2012-December/026247.html
