### PR TITLE
Fix some Makefile issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,12 +18,12 @@ libosmpbf.a: fileformat.pb.o osmformat.pb.o
 	cp *.pb.h ../include/osmpbf/
 
 install:
-	install -m 755 -g root -o root -d $(DESTDIR)/lib
-	install -m 644 -g root -o root libosmpbf.a $(DESTDIR)/lib
-	install -m 755 -g root -o root -d $(DESTDIR)/include/osmpbf
-	install -m 644 -g root -o root ../include/osmpbf/osmpbf.h $(DESTDIR)/include/osmpbf
-	install -m 644 -g root -o root ../include/osmpbf/fileformat.pb.h $(DESTDIR)/include/osmpbf
-	install -m 644 -g root -o root ../include/osmpbf/osmformat.pb.h $(DESTDIR)/include/osmpbf
+	install -m 755 -d $(DESTDIR)/usr/lib
+	install -m 644 libosmpbf.a $(DESTDIR)/usr/lib
+	install -m 755 -d $(DESTDIR)/usr/include/osmpbf
+	install -m 644 ../include/osmpbf/osmpbf.h $(DESTDIR)/usr/include/osmpbf
+	install -m 644 ../include/osmpbf/fileformat.pb.h $(DESTDIR)/usr/include/osmpbf
+	install -m 644 ../include/osmpbf/osmformat.pb.h $(DESTDIR)/usr/include/osmpbf
 
 clean:
 	rm -f *.pb.h *.pb.cc *.pb.o libosmpbf.a

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,8 +10,8 @@ osmpbf-outline: osmpbf-outline.cpp
 	$(CXX) $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
 install:
-	install -m 755 -g root -o root -d $(DESTDIR)/bin
-	install -m 644 -g root -o root -s osmpbf-outline $(DESTDIR)/bin
+	install -m 755 -d $(DESTDIR)/usr/bin
+	install -m 644 -s osmpbf-outline $(DESTDIR)/usr/bin
 
 clean:
 	rm -f osmpbf-outline


### PR DESCRIPTION
Four changes I had to make to integrate OSM-binary into my project:
- Allow overriding Makefile variables from the command line
- Allow overriding protoc path from the command line
- Install to /usr/local per default
- Do not set file user:group to 'root:root' during installation

The first three items should be self-explanatory.

The reason for #4 is when 'make install' is run as root, files will be owned by 'root:root' anyway. When run as user changing user:group will fail. Furthermore, the group 'root' is not available on all systems.

Thanks!
Thomas
