### PR TITLE
I tried to add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+PROJECT(OSMBinary)
+cmake_minimum_required(VERSION 2.8.5)
+
+SET(SEARCH_PREFIX CACHE PATH "Additional prefix to search libraries (Protobuf etc.)" )
+
+SET(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${SEARCH_PREFIX})
+
+include(FindProtobuf)
+find_package(Protobuf REQUIRED)
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
+add_subdirectory(src)
+add_subdirectory(tools)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+PROTOBUF_GENERATE_CPP(CPPS HS fileformat.proto osmformat.proto)
+
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "/O3")        
+else()
+    set(CMAKE_CXX_FLAGS "-O3")        
+endif()
+
+add_library(osmpbf STATIC ${CPPS})
+
+set_target_properties(osmpbf PROPERTIES LINKER_LANGUAGE CXX LANGUAGE CXX)
+
+SET(INCLUDE_INSTALL "include/osmpbf")
+FILE(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+INSTALL(FILES ${files} DESTINATION ${INCLUDE_INSTALL})
+INSTALL(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../include/osmpbf/osmpbf.h" DESTINATION ${INCLUDE_INSTALL})
+install(TARGETS osmpbf LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,31 @@
+SET(PROJECT osmpbf-outline)
+PROJECT(${PROJECT})
+
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "/O3")        
+else()
+    set(CMAKE_CXX_FLAGS "-O3 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64")
+endif()
+
+SET(CPP_SRC osmpbf-outline.cpp)
+SET(HPP_SRC "")
+SET(C_SRC "")
+
+add_executable(${PROJECT} ${HPP_SRC} ${CPP_SRC} ${C_SRC})
+set_target_properties(${PROJECT} PROPERTIES LINKER_LANGUAGE CXX LANGUAGE CXX)
+
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIR})
+
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES(winsock2.h HAVE_WINSOCK)
+if(HAVE_WINSOCK)
+   add_definitions( -DD_HAVE_WINSOCK )
+   SET(WINSOCK_LIB ws2_32)
+endif() 
+
+
+find_package(Threads)
+target_link_libraries(${PROJECT} ${WINSOCK_LIB} ${ZLIB_LIBRARY}  osmpbf ${PROTOBUF_LITE_LIBRARIES})
+
+INSTALL(TARGETS ${PROJECT} RUNTIME DESTINATION bin)

--- a/tools/osmpbf-outline.cpp
+++ b/tools/osmpbf-outline.cpp
@@ -10,8 +10,12 @@
 // zlib compression is used inside the pbf blobs
 #include <zlib.h>
 
-// netinet provides the network-byte-order conversion function
-#include <netinet/in.h>
+// netinet or winsock2 provides the network-byte-order conversion function
+#ifdef D_HAVE_WINSOCK
+    #include <winsock2.h>
+#else
+    #include <netinet/in.h>
+#endif
 
 // this is the header to pbf format
 #include <osmpbf/osmpbf.h>
@@ -86,7 +90,12 @@ void debug(const char* format, ...) {
 // application main method
 int main(int argc, char *argv[]) {
     // check if the output is a tty so we can use colors
+
+#ifdef WIN32
+    usecolor = 0;
+#else
     usecolor = isatty(1);
+#endif
 
     static struct option long_options[] = {
         {"color",                no_argument, 0, 'c'},
@@ -113,7 +122,7 @@ int main(int argc, char *argv[]) {
         err("usage: %s [--color] file.osm.pbf", argv[0]);
 
     // open specified file
-    FILE *fp = fopen(argv[optind], "r");
+    FILE *fp = fopen(argv[optind], "rb");
 
     // read while the file has not reached its end
     while(!feof(fp)) {


### PR DESCRIPTION
To solve the issues with cross-platform compiling and installation I propose to add CMake project files. I have also added some #ifdef to osmpbf-outline.cpp to allow it compile and work on Windows.
