### PR TITLE
Make CXX/CXXFLAGS overridable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 
-CXX = g++
-CXXFLAGS = -O3
+CXX ?= g++
+CXXFLAGS ?= -O3
 AR = ar
 
 all: libosmpbf.a ../include/osmpbf/fileformat.pb.h ../include/osmpbf/osmformat.pb.h

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,8 @@
 
-CXX = g++
-CXXFLAGS = -g -I../include
-LDFLAGS = -L../src -lpthread -lz -lprotobuf-lite -losmpbf
+CXX ?= g++
+CXXFLAGS ?= -g
+CXXFLAGS += -I../include
+LDFLAGS += -L../src -pthread -lz -lprotobuf-lite -losmpbf
 
 all: osmpbf-outline
 


### PR DESCRIPTION
This makes it easier to support systemwide compiler settings.
While here, link with pthreads in a more correct way (-pthread instead
of -lpthread).
