### PR TITLE
Copy header files individually, instead of both files twice.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ libosmpbf.a: fileformat.pb.o osmformat.pb.o
 
 %.pb.cc ../include/osmpbf/%.pb.h: %.proto
 	$(PROTOC) --proto_path=. --cpp_out=. $<
-	cp *.pb.h ../include/osmpbf/
+	cp -v $(subst .proto,.pb.h,$<) ../include/osmpbf/
 
 install:
 	install -m 755 -d $(DESTDIR)$(PREFIX)/lib


### PR DESCRIPTION
The osmpbf (1.3.3-1) build for Debian failed on the mipsel architecture.

The Debian package uses parallel builds which caused the following failure:

```
protoc --proto_path=. --cpp_out=. fileformat.proto
protoc --proto_path=. --cpp_out=. osmformat.proto
cp *.pb.h ../include/osmpbf/
cp *.pb.h ../include/osmpbf/
g++ -g -O2 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -Wall -Wextra -pedantic -Wredundant-decls -Wdisabled-optimization -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wno-long-long -fPIC -c -o osmformat.pb.o osmformat.pb.cc
cp: cannot create regular file '../include/osmpbf/fileformat.pb.h': File exists
```

This change fixes the race condition by copying the header files separately,
instead of copying both header files twice.

With this patch applied, the builds succeeded on all architectures where
OpenJDK 7 is available.

Origin: http://anonscm.debian.org/gitweb/?p=pkg-grass/osmpbf.git;a=commitdiff;h=adcf891b95609e375130438dc431e96017bbbbf8
