### PR TITLE
update to protocol buffers 2.6.1 in pom.xml, fixes #24.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3</version>
+  <version>1.3.4-SNAPSHOT</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.4.1</version>
+      <version>2.6.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Update the version of Protocol Buffers in the POM. Also bump Maven version number so that we're not making changes to a release version.
