### PR TITLE
Make the generated includes visible to CMake.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,13 @@ add_library(osmpbf STATIC ${CPPS})
 
 set_target_properties(osmpbf PROPERTIES LINKER_LANGUAGE CXX LANGUAGE CXX)
 
-ADD_CUSTOM_COMMAND(TARGET osmpbf POST_BUILD  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/src/fileformat.pb.h ${CMAKE_SOURCE_DIR}/include/osmpbf)
-ADD_CUSTOM_COMMAND(TARGET osmpbf POST_BUILD  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/src/osmformat.pb.h ${CMAKE_SOURCE_DIR}/include/osmpbf)
+ADD_CUSTOM_COMMAND(TARGET osmpbf POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/src/fileformat.pb.h ${CMAKE_SOURCE_DIR}/include/osmpbf
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/src/osmformat.pb.h ${CMAKE_SOURCE_DIR}/include/osmpbf
+    BYPRODUCTS
+        ${CMAKE_SOURCE_DIR}/include/osmpbf/fileformat.pb.h
+        ${CMAKE_SOURCE_DIR}/include/osmpbf/osmformat.pb.h
+)
 
 SET(INCLUDE_INSTALL "include/osmpbf")
 SET(files ${CMAKE_SOURCE_DIR}/include/osmpbf/osmpbf.h ${CMAKE_BINARY_DIR}/src/osmformat.pb.h ${CMAKE_BINARY_DIR}/src/fileformat.pb.h)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,8 @@ endif()
 SET(CPP_SRC osmpbf-outline.cpp)
 SET(HPP_SRC "")
 SET(C_SRC "")
+set_source_files_properties(${CPP_SRC}
+    OBJECT_DEPENDS "${CMAKE_SOURCE_DIR}/include/osmpbf/fileformat.pb.h;${CMAKE_SOURCE_DIR}/include/osmpbf/osmformat.pb.h")
 include_directories("${CMAKE_SOURCE_DIR}/include")
 
 add_executable(${PROJECT} ${HPP_SRC} ${CPP_SRC} ${C_SRC})


### PR DESCRIPTION
For heavily parallel builds (e.g. via ninja) at least with CMake 3.9,
the tools start building before the headers have been copied to their
src-dir location. Add an explicit dependency.