### PR TITLE
update protobuf-java from 2.4.1 to 3.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.4.1</version>
+      <version>3.11.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The package in which we use your library depends on a more recent version of protobuf-java. In order to get this library to work with our stack, I had to bump the protobuf-java version. I did this all locally, but it would be nice to upstream this if possible. I still need to test that the newly generated proto classes are able to parse the data properly. I am at the point where I have code that compiles and runs on our test cases. 

In order to produce a jar with the correct package names I had to shade crosby.binary. I have copied the below in this comment, but did not include it in the PR as I assume the maintainers have some either tried and true way of doing this when publishing the artifact to maven central. 

I am happy to do whatever other polishing that may be needed to get this PR through. Took the liberty of incrementing the minor version in this PR, but happy to do something different if there is another workflow. 

shading code snippet:
```
 <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-shade-plugin</artifactId>
        <version>3.2.1</version>
        <executions>
          <execution>
            <phase>package</phase>
            <goals>
              <goal>shade</goal>
            </goals>
            <configuration>
              <relocations>
                <relocation>
                  <pattern>crosby.binary</pattern>
                  <shadedPattern>org.openstreetmap.osmosis.osmbinary</shadedPattern>
                </relocation>
              </relocations>
            </configuration>
          </execution>
        </executions>
      </plugin>
```

