### PR TITLE
Fix Java build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3</version>
+  <version>1.4.0</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>
@@ -33,19 +33,21 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
       <plugin>
-        <groupId>com.google.protobuf.tools</groupId>
-        <artifactId>maven-protoc-plugin</artifactId>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
         <executions>
           <execution>
             <id>generate-sources</id>
             <goals>
               <goal>compile</goal>
+              <goal>test-compile</goal>
             </goals>
             <phase>generate-sources</phase>
             <configuration>
@@ -78,7 +80,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.4.1</version>
+      <version>3.13.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
- Java 8 (since Java 1.5 is no longer supported by modern Maven)
- Use org.xolstice.maven.plugins (the other one is no longer available)
- Upgrade to protobuf-java 3.13.0

Closes https://github.com/openstreetmap/OSM-binary/issues/24
Closes https://github.com/openstreetmap/OSM-binary/pull/25
Closes https://github.com/openstreetmap/OSM-binary/pull/37

cc: @joto 