### PR TITLE
Enable GitHub Actions for Java

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,16 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml


### PR DESCRIPTION
Reference: https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-maven#starting-with-a-maven-workflow-template

@joto, it _should_ work, since it is a 1:1 copy of the Maven workflow template…