### PR TITLE
GitHub Actions: setup protoc

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -12,5 +12,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
       - name: Build with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
The `protoc` compiler needs to be installed for a successful workflow.

Follow-up of https://github.com/openstreetmap/OSM-binary/pull/40

Ref: https://github.com/marketplace/actions/setup-protoc

cc: @joto 