### PR TITLE
Support hardening buildflags set in the environment.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,10 +19,10 @@ libosmpbf.a: fileformat.pb.o osmformat.pb.o
 	$(AR) -cr $@ fileformat.pb.o osmformat.pb.o
 
 libosmpbf.so: fileformat.pb.o osmformat.pb.o
-	$(CXX) -shared -Wl,-soname,$(SONAME) -o $@ fileformat.pb.o osmformat.pb.o
+	$(CXX) $(CPPFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(SONAME) -o $@ fileformat.pb.o osmformat.pb.o
 
 %.pb.o: %.pb.cc
-	$(CXX) $(CXXFLAGS) -fPIC -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fPIC -c -o $@ $<
 
 %.pb.cc ../include/osmpbf/%.pb.h: %.proto
 	$(PROTOC) --proto_path=. --cpp_out=. $<

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -12,7 +12,7 @@ LDFLAGS  += -L../src -pthread -lz -lprotobuf -losmpbf
 all: osmpbf-outline
 
 osmpbf-outline: osmpbf-outline.cpp
-	$(CXX) $(CXXFLAGS) -o $@ $< $(LDFLAGS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 
 install:
 	install -m 755 -d $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
The lintian QA tool reported that not all hardening buildflags were used for the Debian package build.

These changes use the buildflags set in the environment.

`CPPFLAGS` needs to be used for `-D_FORTIFY_SOURCE=2`, and `LDFLAGS` for `-Wl,-z,relro -Wl,-z,now`.