### PR TITLE
Use the GNUInstallDirs module to set installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 
 project(OSMBinary)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(Protobuf REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,16 +2,16 @@ protobuf_generate_cpp(CPPS HS fileformat.proto osmformat.proto)
 
 add_library(osmpbf STATIC ${CPPS})
 target_include_directories(osmpbf SYSTEM PUBLIC ${Protobuf_INCLUDE_DIRS})
-install(TARGETS osmpbf ARCHIVE DESTINATION lib)
+install(TARGETS osmpbf ARCHIVE)
 
 add_library(osmpbf_shared SHARED ${CPPS})
 target_link_libraries(osmpbf_shared PRIVATE protobuf::libprotobuf)
 target_include_directories(osmpbf_shared SYSTEM PUBLIC ${Protobuf_INCLUDE_DIRS})
 set_target_properties(osmpbf_shared PROPERTIES OUTPUT_NAME osmpbf)
-install(TARGETS osmpbf_shared LIBRARY DESTINATION lib)
+install(TARGETS osmpbf_shared LIBRARY)
 
 install(FILES ${CMAKE_SOURCE_DIR}/include/osmpbf/osmpbf.h
               ${CMAKE_BINARY_DIR}/osmpbf/osmformat.pb.h
               ${CMAKE_BINARY_DIR}/osmpbf/fileformat.pb.h
-        DESTINATION "include/osmpbf")
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/osmpbf)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,5 +11,5 @@ add_executable(osmpbf-outline osmpbf-outline.cpp)
 target_include_directories(osmpbf-outline SYSTEM PRIVATE ${ZLIB_INCLUDE_DIR})
 target_link_libraries(osmpbf-outline PRIVATE osmpbf ZLIB::ZLIB protobuf::libprotobuf)
 
-install(TARGETS osmpbf-outline RUNTIME DESTINATION bin)
-install(FILES osmpbf-outline.1 DESTINATION share/man/man1)
+install(TARGETS osmpbf-outline RUNTIME)
+install(FILES osmpbf-outline.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)


### PR DESCRIPTION
This ensures that things like the library directory to use can be configured from the cmake command line so that systems using `lib64` rather than `lib` can choose to install there.