### PR TITLE
Set the version number for the shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(osmpbf_shared SHARED ${CPPS})
 target_link_libraries(osmpbf_shared PRIVATE protobuf::libprotobuf)
 target_include_directories(osmpbf_shared SYSTEM PUBLIC ${Protobuf_INCLUDE_DIRS})
 set_target_properties(osmpbf_shared PROPERTIES OUTPUT_NAME osmpbf)
+set_target_properties(osmpbf_shared PROPERTIES VERSION 1.5.0)
+set_target_properties(osmpbf_shared PROPERTIES SOVERSION 1)
 install(TARGETS osmpbf_shared LIBRARY DESTINATION lib)
 
 install(FILES ${CMAKE_SOURCE_DIR}/include/osmpbf/osmpbf.h


### PR DESCRIPTION
This sets the shared library version number though probably not in the best way so it may need some work.

The old makefiles were just setting it to the package version, which I think was a hack I submitted some time ago, though that's not really correct and the shared library version should really be set based on changes in the library ABI rather than the overall package.