### PR TITLE
Ant build

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -3,9 +3,8 @@ name: Java CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  maven-ubuntu18:
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install protobuf-compiler
@@ -15,3 +14,40 @@ jobs:
           java-version: 1.8
       - name: Build with Maven
         run: mvn -B package --file pom.xml
+
+  maven-ubuntu20:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get install protobuf-compiler
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+  ant-ubuntu18:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get install protobuf-compiler libprotobuf-java
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Ant
+        run: ant
+
+  ant-ubuntu20:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get install protobuf-compiler libprotobuf-java
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Ant
+        run: ant
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ something more complete see [libosmium](https://osmcode.org/libosmium/).
 
 ## Java Version
 
+### Building with Maven
+
 We publish the Java library to [Maven Central](https://search.maven.org/):
 
 ```xml
@@ -34,8 +36,21 @@ To build the Java library run:
 mvn package
 ```
 
-For a Java usage example, see [`ReadFileTest`](https://github.com/openstreetmap/OSM-binary/blob/master/test.java/crosby/binary/ReadFileTest.java)
+For a Java usage example, see
+[`ReadFileTest`](https://github.com/openstreetmap/OSM-binary/blob/master/test.java/crosby/binary/ReadFileTest.java).
 
+### Building with Ant
+
+If you can not use Maven for some reason you can use the
+[Ant](https://ant.apache.org/) instead:
+
+```sh
+ant
+```
+
+This will build `osmpbf.jar` in the main directory.
+
+This build is also used for Debian packaging.
 
 ## C++ Version
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+protoc --java_out=generated.java src/osmformat.proto
+protoc --java_out=generated.java src/fileformat.proto

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<project name="osmpbf" default="all" basedir=".">
+
+	<property name="src.dir" location="src.java"/>
+	<property name="src.generated.dir" location="generated.java"/>
+	<property name="build.dir" location="build"/>
+	<property name="build.jar" location="osmpbf.jar"/>
+
+	<target name="init">
+		<mkdir dir="${src.generated.dir}"/>
+		<mkdir dir="${build.dir}"/>
+	</target>
+
+	<target name="clean">
+		<delete dir="${src.generated.dir}"/>
+		<delete dir="${build.dir}"/>
+		<delete file="${build.jar}"/>
+	</target>
+
+	<target name="build" depends="init">
+		<exec executable="/bin/sh">
+			<arg value="./build.sh"/>
+		</exec>
+		<javac includeantruntime="false" destdir="${build.dir}">
+			<src path="${src.dir}"/>
+			<src path="${src.generated.dir}"/>
+			<classpath>
+				<fileset file="/usr/share/java/protobuf.jar"/>
+				<fileset file="/usr/share/java/protobuf-java.jar"/>
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="dist" depends="build">
+		<jar destfile="${build.jar}" basedir="${build.dir}"/>
+	</target>
+	
+	<target name="all" depends="dist">
+	</target>
+
+</project>
+


### PR DESCRIPTION
Reinstate ant build config, document it and add to CI build.

It is important that we support package maintainers. It is a bit annoying to have to support several build methods, but on the other hand: Its not that there are a lot of changes in the code here or that the Ant build is especially complicated.

See also discussion on #56.
