### PR TITLE
Set shared library version and bump version number to 1.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(osmpbf VERSION 1.5.0)
+project(osmpbf VERSION 1.6.0)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We publish the Java library to [Maven Central](https://search.maven.org/):
 <dependency>
   <groupId>org.openstreetmap.pbf</groupId>
   <artifactId>osmpbf</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 

--- a/include/osmpbf/osmpbf.h
+++ b/include/osmpbf/osmpbf.h
@@ -18,7 +18,7 @@
 // this describes the high-level OSM objects
 #include <osmpbf/osmformat.pb.h> // IWYU pragma: export
 
-#define OSMPBF_VERSION "1.5.0"
+#define OSMPBF_VERSION "1.6.0"
 
 namespace OSMPBF {
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.openstreetmap.pbf</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/openstreetmap/OSM-binary</url>


### PR DESCRIPTION
Depends on a working Maven deployment to oss.sonatype.org!

Fixes #85.
