### PR TITLE
Set Java version to 1.8 to match Maven build.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -21,7 +21,7 @@
 		<exec executable="/bin/sh">
 			<arg value="./build.sh"/>
 		</exec>
-		<javac includeantruntime="false" destdir="${build.dir}">
+		<javac includeantruntime="false" destdir="${build.dir}" source="1.8" target="1.8">
 			<src path="${src.dir}"/>
 			<src path="${src.generated.dir}"/>
 			<classpath>


### PR DESCRIPTION
Not setting the version results in much too high bytecode version to be used which complicates compatibility with reverse dependencies like osmosis.